### PR TITLE
Fix rbenv prefix in deploy script

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,6 +14,7 @@ set :deploy_to, "/var/www/#{fetch(:application)}_#{fetch(:stage)}"
 set :rbenv_ruby, "#{File.read('.ruby-version').chomp}"
 set :rbenv_type, :user
 set :rbenv_map_bins, %w{rake gem bundle ruby rails}
+set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
 
 # Default value for :scm is :git
 # set :scm, :git


### PR DESCRIPTION
When deploying it couldn't find ruby 2.2.3