### PR TITLE
Fix 3 rubocop offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'oj'
 # gem 'capistrano-rails', group: :development
 
 group :development, :test do
+  gem "rubocop"
   # Call 'byebug' anywhere in the code to stop execution and get a debugger
   # console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -120,7 +123,10 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     oj (2.14.1)
+    parser (2.2.3.0)
+      ast (>= 1.1, < 3.0)
     pg (0.18.4)
+    powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -154,6 +160,7 @@ GEM
       activesupport (= 4.2.5)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
@@ -180,6 +187,14 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    rubocop (0.35.1)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.3.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      tins (<= 1.6.0)
+    ruby-progressbar (1.7.5)
     sass (3.4.20)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -206,6 +221,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
+    tins (1.6.0)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -238,6 +254,7 @@ DEPENDENCIES
   rabl
   rails (= 4.2.5)
   rspec-rails (~> 3.0)
+  rubocop
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
@@ -246,4 +263,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,4 @@
 class ReportsController < ApplicationController
-
   def create
     @report = Report.new report_create_params
     @report.agent_ip = request.headers['X-Forwarded-For'] ||
@@ -19,17 +18,15 @@ class ReportsController < ApplicationController
   protected
 
   def report_create_params
-    params
-      .require(:report)
-      .permit(
-        :latitude,
-        :longitude,
-        :description,
-        :agent,
-        :reporter_network,
-        :reporter_username,
-        :source_url,
-        :image_url
-      )
+    params.require(:report).permit(
+      :latitude,
+      :longitude,
+      :description,
+      :agent,
+      :reporter_network,
+      :reporter_username,
+      :source_url,
+      :image_url
+    )
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Report, type: :model do
-
   describe 'creation' do
     it 'can be created' do
       r = Report.new valid_attributes


### PR DESCRIPTION
Offenses:

    app/controllers/reports_controller.rb:2:1: C: Style/EmptyLinesAroundClassBody: Extra empty line detected at class body beginning.
    app/controllers/reports_controller.rb:21:3: C: Metrics/MethodLength: Method has too many lines. [12/10] (https://github.com/bbatsov/ruby-style-guide#short-methods)
      def report_create_params
      ^^^
    spec/models/report_spec.rb:4:1: C: Style/EmptyLinesAroundBlockBody: Extra empty line detected at block body beginning.

31 files inspected, 3 offenses detected